### PR TITLE
Groups permission

### DIFF
--- a/forecast-admin/forecast/opportunities/management/commands/create_GSA_staff_group.py
+++ b/forecast-admin/forecast/opportunities/management/commands/create_GSA_staff_group.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Create User '
+
+    def handle(self, *args, **options):
+        g, created = Group.objects.get_or_create(name='GSA_staff')
+        opp_add_perm = Permission.objects.get(name='Can add opportunity')
+        opp_change_perm = Permission.objects.get(name='Can change opportunity')
+        g.permissions.add(opp_add_perm)
+        g.permissions.add(opp_change_perm)

--- a/forecast-admin/forecast/opportunities/models.py
+++ b/forecast-admin/forecast/opportunities/models.py
@@ -16,7 +16,7 @@ class Office(models.Model):
 
 
 # The OSBU Advisor is the Office of Small Business Utilization specialist
-# who is responsible for the forecast data... 
+# who is responsible for the forecast data...
 class OSBUAdvisor(models.Model):
     name = models.CharField(max_length=200, blank=True, null=True)
     email = models.EmailField(max_length=200, blank=True, null=True)

--- a/forecast-admin/forecast/opportunities/test/test_admin.py
+++ b/forecast-admin/forecast/opportunities/test/test_admin.py
@@ -29,24 +29,26 @@ class OSBUAdvisorAdminTests(TestCase):
 
 class OfficeAuthorizationTests(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user("testUserNoPerm")
-        self.user.is_staff = True
-        self.user.save()
+        call_command('create_GSA_staff_group')
+        self.g, created = Group.objects.get_or_create(name='GSA_staff')
 
     def test_command_output(self):
         """
         Test management command to see if GSA_staff group is created with
         permission to add and change opportunities.
         """
-        call_command('create_GSA_staff_group')
-        g, created = Group.objects.get_or_create(name='GSA_staff')
         opp_add_perm = Permission.objects.get(name='Can add opportunity')
         opp_change_perm = Permission.objects.get(name='Can change opportunity')
-        self.assertEqual(g.permissions.filter(
+        opp_delete_perm = Permission.objects.get(name='Can delete opportunity')
+        self.assertEqual(self.g.permissions.filter(
             name='Can add opportunity')[0],
             opp_add_perm
         )
-        self.assertEqual(g.permissions.filter(
+        self.assertEqual(self.g.permissions.filter(
             name='Can change opportunity')[0],
             opp_change_perm
+        )
+        self.assertNotEqual(self.g.permissions.filter(
+            name='Can delete opportunity'),
+            opp_delete_perm
         )

--- a/forecast-admin/forecast/opportunities/test/test_admin.py
+++ b/forecast-admin/forecast/opportunities/test/test_admin.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 from django.test import Client
 
+from django.contrib.auth.models import User, Group, Permission
+
+from django.core.management import call_command
 from django.contrib.admin.options import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from opportunities.models import OSBUAdvisor
@@ -21,4 +24,29 @@ class OSBUAdvisorAdminTests(TestCase):
         self.assertEqual(
             list(ma.get_form(self.client).base_fields),
             ['name', 'email', 'phone']
+        )
+
+
+class OfficeAuthorizationTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("testUserNoPerm")
+        self.user.is_staff = True
+        self.user.save()
+
+    def test_command_output(self):
+        """
+        Test management command to see if GSA_staff group is created with
+        permission to add and change opportunities.
+        """
+        call_command('create_GSA_staff_group')
+        g, created = Group.objects.get_or_create(name='GSA_staff')
+        opp_add_perm = Permission.objects.get(name='Can add opportunity')
+        opp_change_perm = Permission.objects.get(name='Can change opportunity')
+        self.assertEqual(g.permissions.filter(
+            name='Can add opportunity')[0],
+            opp_add_perm
+        )
+        self.assertEqual(g.permissions.filter(
+            name='Can change opportunity')[0],
+            opp_change_perm
         )


### PR DESCRIPTION
This creates a user group (GSA_staff) that can add and change opportunities, but not delete them.
