### PR TITLE
Codecov switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .coverage
 **/.cache
 **/.sass-cache
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ cache:
 #   space: vladlen.zvenyach
 script: coverage run ./manage.py test
 after_success:
-  - codecov
-  - coveralls
+  - cd forecast-admin/forecast && codecov
+  - cd forecast-admin/forecast && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 #   api: https://api.cloud.gov
 #   organization: sandbox
 #   space: vladlen.zvenyach
-script: coverage run ./manage.py test
+script: py.test --cov opportunities --cov-report term-missing
 after_success:
   - cd forecast-admin/forecast && codecov
   - cd forecast-admin/forecast && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.4"
   - "3.5"
+before_install: pip install codecov
 install: cd forecast-admin/forecast && pip install -r requirements.txt
 cache:
   directories:
@@ -17,4 +18,5 @@ cache:
 #   space: vladlen.zvenyach
 script: coverage run ./manage.py test
 after_success:
+  - codecov
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ cache:
 #   space: vladlen.zvenyach
 script: py.test --cov opportunities --cov-report term-missing
 after_success:
-  - cd forecast-admin/forecast && codecov
-  - cd forecast-admin/forecast && coveralls
+  - codecov
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSBU Forecast
 
-[![Build Status](https://travis-ci.org/18F/osbu-forecast-api.svg?branch=master)](https://travis-ci.org/18F/osbu-forecast-api)[![Code Climate](https://codeclimate.com/github/18F/osbu-forecast-api/badges/gpa.svg)](https://codeclimate.com/github/18F/osbu-forecast-api)[![Coverage Status](https://coveralls.io/repos/18F/osbu-forecast-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/osbu-forecast-api?branch=master)
+[![Build Status](https://travis-ci.org/18F/forecast.svg?branch=master)](https://travis-ci.org/18F/forecast)[![Code Climate](https://codeclimate.com/github/18F/osbu-forecast-api/badges/gpa.svg)](https://codeclimate.com/github/18F/osbu-forecast-api)[![codecov.io](https://codecov.io/github/codecov/codecov-ruby/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-ruby?branch=master)
 
 An API that provides an interface for the OSBU Forecast Tool, which is an MVP of a better version of http://www.gsa.gov/portal/content/101163. To learn more about the Office of Small Business Utilization at GSA, visit http://www.gsa.gov/portal/category/21015.
 


### PR DESCRIPTION
Coveralls seems to be busted (http://stackoverflow.com/questions/28475470/broken-coveralls-no-longer-reporting-coverage-from-travisci), and I'm going to try and make the switch to codecov.
