### PR TITLE
Re-activate search bar

### DIFF
--- a/forecast-admin/forecast/opportunities/templates/main.html
+++ b/forecast-admin/forecast/opportunities/templates/main.html
@@ -125,9 +125,20 @@
     })
   })
 
-  $(".search").keyup(function () {
-    opportunitiesList.search($(this).val());
-  });
+  $(document).ready(function () {
+    // Search within list of opportunities
+    $(".search").keyup(function () {
+      opportunitiesList.search($(this).val());
+    });
+
+    // Disable search while it doesn't actually query the DB
+    $(".search").keypress(function (event) {
+      if (event.which == '13') {
+        event.preventDefault();
+      }
+    })
+  })
+
 </script>
 
 {% endblock %}

--- a/forecast-admin/forecast/opportunities/templates/main.html
+++ b/forecast-admin/forecast/opportunities/templates/main.html
@@ -62,7 +62,13 @@
    *Initializes list.js
    **/
   var listOptions = {
-    valueNames: ['award_status', 'place_of_performance_state', 'naics', 'award_amount', 'estimated_fiscal_year_quarter']
+    valueNames: [
+      'award_status',
+      'place_of_performance_state',
+      'naics',
+      'award_amount',
+      'estimated_fiscal_year_quarter'
+    ]
   };
   var opportunitiesList = new List('opportunities', listOptions)
   var data = {}
@@ -112,6 +118,10 @@
       })
     })
   })
+
+  $(".search").keyup(function () {
+    opportunitiesList.search($(this).val());
+  });
 </script>
 
 {% endblock %}

--- a/forecast-admin/forecast/opportunities/templates/main.html
+++ b/forecast-admin/forecast/opportunities/templates/main.html
@@ -67,7 +67,13 @@
       'place_of_performance_state',
       'naics',
       'award_amount',
-      'estimated_fiscal_year_quarter'
+      'estimated_fiscal_year_quarter',
+      'description',
+      'funding_agency',
+      'estimated_fiscal_year',
+      'place_of_performance_city',
+      'contract_type',
+      'office'
     ]
   };
   var opportunitiesList = new List('opportunities', listOptions)


### PR DESCRIPTION
Two things remain:

(1) We should discuss which fields should be included in the search. Should it be all of them or a subset?

(2) Using the `search` button only reloaded the page, so it is temporarily disabled. Is that a feature that we need? The search filters on the same page, so loading a results page isn't necessary, but perhaps users would want to share searches.
