### PR TITLE
admin icon alignment

### DIFF
--- a/forecast-admin/forecast/static/admin/css/base.css
+++ b/forecast-admin/forecast/static/admin/css/base.css
@@ -771,7 +771,7 @@ table thead th.sorted .sortoptions a {
 }
 
 table thead th.sorted .sortoptions a.sortremove {
-    background-position: 0 -69px;
+    background-position: 0 -73px;
     background-size: 7px;
 }
 
@@ -787,13 +787,13 @@ table thead th.sorted .sortoptions a.sortremove:after {
 }
 
 table thead th.sorted .sortoptions a.ascending {
-    background-position: 0px -91px;
-    background-size: 7px;
+    background-position: 0px -83px;
+    background-size: 6px;
 }
 
 table thead th.sorted .sortoptions a.descending {
     top: 1px;
-    background-position: 0px -81px;
+    background-position: 0px -87px;
     background-size: 7px;
 }
 

--- a/forecast-admin/forecast/static/admin/css/widgets.css
+++ b/forecast-admin/forecast/static/admin/css/widgets.css
@@ -113,7 +113,7 @@
 }
 
 .selector-remove {
-    background: url(../img/svg/selector-icons.svg) 0 -66px no-repeat;
+    background: url(../img/svg/selector-icons.svg) 0 -64px no-repeat;
     cursor: default;
 }
 
@@ -151,12 +151,12 @@ a.selector-chooseall {
 }
 
 a.active.selector-chooseall {
-    background-position: 100% -172px;
+    background-position: 100% -177px;
     cursor: pointer;
 }
 
 a.selector-clearall {
-    background: url(../img/svg/selector-icons.svg) 0 -128px no-repeat;
+    background: url(../img/svg/selector-icons.svg) 0 -129px no-repeat;
     cursor: default;
 }
 


### PR DESCRIPTION
For #77. This PR addresses the misalignment of some of the icons on the Admin page. [Trello ticket for reference](https://trello.com/c/d347tzV8/117-visual-bug-some-icons-misaligned-on-admin)

@stvnrlly when you get a chance could you review?
They now look like this:

<img width="517" alt="screen shot 2016-04-04 at 3 34 34 pm" src="https://cloud.githubusercontent.com/assets/4803473/14262383/dadd9eec-fa7a-11e5-9de8-ec62b93a5fb6.png">
<img width="39" alt="screen shot 2016-04-04 at 3 34 38 pm" src="https://cloud.githubusercontent.com/assets/4803473/14262385/dae138d6-fa7a-11e5-9a55-92c1dd754293.png">
<img width="80" alt="screen shot 2016-04-04 at 3 34 56 pm" src="https://cloud.githubusercontent.com/assets/4803473/14262384/dae0e11a-fa7a-11e5-91a9-1a5503a6e66d.png">
